### PR TITLE
Static exectuor: intra-process optim

### DIFF
--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -86,6 +86,10 @@ public:
 
   RCLCPP_PUBLIC
   void
+  set_condition_variable(std::shared_ptr<std::condition_variable>) override {};
+
+  RCLCPP_PUBLIC
+  void
   add_node(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
 
@@ -125,6 +129,10 @@ public:
   get_number_of_waitables() {return exec_list_.number_of_waitables;}
 
   RCLCPP_PUBLIC
+  size_t
+  get_number_of_ip_waitables() {return ip_exec_list_.number_of_waitables;}
+
+  RCLCPP_PUBLIC
   rclcpp::SubscriptionBase::SharedPtr
   get_subscription(size_t i) {return exec_list_.subscription[i];}
 
@@ -144,6 +152,10 @@ public:
   rclcpp::Waitable::SharedPtr
   get_waitable(size_t i) {return exec_list_.waitable[i];}
 
+  RCLCPP_PUBLIC
+  rclcpp::Waitable::SharedPtr
+  get_ip_waitable(size_t i) {return ip_exec_list_.waitable[i];}
+
 private:
   /// Nodes guard conditions which trigger this waitable
   std::list<const rcl_guard_condition_t *> guard_conditions_;
@@ -159,6 +171,9 @@ private:
 
   /// Executable list: timers, subscribers, clients, services and waitables
   rclcpp::executor::ExecutableList exec_list_;
+
+  /// Intra-process executable list: just waitables
+  rclcpp::executor::ExecutableList ip_exec_list_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -118,14 +118,21 @@ public:
   provide_intra_process_message(ConstMessageSharedPtr message)
   {
     buffer_->add_shared(std::move(message));
-    trigger_guard_condition();
+    trigger_condition_variable();
   }
 
   void
   provide_intra_process_message(MessageUniquePtr message)
   {
     buffer_->add_unique(std::move(message));
-    trigger_guard_condition();
+    trigger_condition_variable();
+  }
+
+  void
+  set_condition_variable(
+    std::shared_ptr<std::condition_variable> intra_process_cv) override
+  {
+    intra_process_cv_ = intra_process_cv;
   }
 
   bool
@@ -140,6 +147,12 @@ private:
   {
     rcl_ret_t ret = rcl_trigger_guard_condition(&gc_);
     (void)ret;
+  }
+
+  void
+  trigger_condition_variable() override
+  {
+    intra_process_cv_->notify_one();
   }
 
   template<typename T>

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -70,13 +70,23 @@ public:
   rmw_qos_profile_t
   get_actual_qos() const;
 
+  RCLCPP_PUBLIC
+  virtual void
+  set_condition_variable(std::shared_ptr<std::condition_variable>) = 0;
+
 protected:
   std::recursive_mutex reentrant_mutex_;
   rcl_guard_condition_t gc_;
 
+  /// Condition variable for signaling the executor
+  std::shared_ptr<std::condition_variable> intra_process_cv_ = std::make_shared<std::condition_variable>();
+
 private:
   virtual void
   trigger_guard_condition() = 0;
+
+  virtual void
+  trigger_condition_variable() = 0;
 
   std::string topic_name_;
   rmw_qos_profile_t qos_profile_;

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -97,6 +97,10 @@ public:
   bool
   is_ready(rcl_wait_set_t * wait_set) override;
 
+  RCLCPP_PUBLIC
+  void
+  set_condition_variable(std::shared_ptr<std::condition_variable>) override {};
+
 protected:
   rcl_event_t event_handle_;
   size_t wait_set_event_index_;

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP__WAITABLE_HPP_
 #define RCLCPP__WAITABLE_HPP_
 
+#include <condition_variable>
+
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -146,6 +148,11 @@ public:
   virtual
   void
   execute() = 0;
+
+  /// Set condition variable based on std::condition_variable
+  virtual
+  void
+  set_condition_variable(std::shared_ptr<std::condition_variable>) = 0;
 };  // class Waitable
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/wall_timer.hpp
+++ b/rclcpp/include/rclcpp/wall_timer.hpp
@@ -1,0 +1,72 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <condition_variable>
+
+namespace rclcpp
+{
+namespace executors
+{
+
+/// Timer based on std::chrono. Periodically executes user-specified callbacks.
+template<typename FunctorT>
+class WallTimer
+{
+public:
+  WallTimer(
+    std::chrono::microseconds period,
+    FunctorT && callback)
+     : period_(period)
+  {
+    callbacks_.push_back(callback);
+  }
+
+  void
+  execute_callbacks()
+  {
+    for (const auto& callback : callbacks_){
+      callback();
+    }
+  }
+
+  void start()
+  {
+    std::thread([this]()
+    {
+      while(rclcpp::ok())
+      {
+        auto wake_up_time = std::chrono::steady_clock::now() + period_;
+        execute_callbacks();
+        std::this_thread::sleep_until(wake_up_time);
+      }
+    }).detach();
+  }
+
+  void
+  add_callback(FunctorT callback)
+  {
+    callbacks_.push_back(callback);
+  }
+
+protected:
+  RCLCPP_DISABLE_COPY(WallTimer)
+
+  std::chrono::microseconds period_;
+  std::vector<FunctorT> callbacks_;
+};
+
+} // namespace executors
+} // namespace rclcpp

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -32,6 +32,7 @@ StaticExecutorEntitiesCollector::~StaticExecutorEntitiesCollector()
     }
   }
   exec_list_.clear();
+  ip_exec_list_.clear();
   weak_nodes_.clear();
   guard_conditions_.clear();
 }
@@ -44,6 +45,8 @@ StaticExecutorEntitiesCollector::init(
 {
   // Empty initialize executable list
   exec_list_ = executor::ExecutableList();
+  // Empty initialize intra-process executable list
+  ip_exec_list_ = executor::ExecutableList();
   // Get executor's wait_set_ pointer
   p_wait_set_ = p_wait_set;
   // Get executor's memory strategy ptr
@@ -96,6 +99,7 @@ void
 StaticExecutorEntitiesCollector::fill_executable_list()
 {
   exec_list_.clear();
+  ip_exec_list_.clear();
 
   for (auto & weak_node : weak_nodes_) {
     auto node = weak_node.lock();
@@ -141,6 +145,7 @@ StaticExecutorEntitiesCollector::fill_executable_list()
         [this](const rclcpp::Waitable::SharedPtr & waitable) {
           if (waitable) {
             exec_list_.add_waitable(waitable);
+            ip_exec_list_.add_waitable(waitable);
           }
           return false;
         });


### PR DESCRIPTION
Now you can choose:

`executor->spin(); //Should work as always`

`executor->spin_intra_process(); // Should do what we want`

Be aware that as we create our own std::chrono timers, we need to pass the callbacks the executor:

`executor->add_callbacks(node->get_publishers_callbacks());`

