### PR TITLE
Add tests and use previous events

### DIFF
--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -77,7 +77,7 @@ QOSEventHandlerBase::set_events_executor_callback(
     &event_handle_,
     executor_callback,
     executor_callback_data,
-    false /* Discard previous events */);
+    true /* Use previous events */);
 
   if (RCL_RET_OK != ret) {
     throw std::runtime_error("Couldn't set EventsExecutor's callback in QOSEventHandlerBase");


### PR DESCRIPTION
When setting the events executor callback to Events listeners, now we ask to take into account events that happened before the callback was assigned.
This is because many of the events are generated right when an entity is created. For example if the QoS of a new subscription is not compatible with a publisher QoS, an event will be generated. But these events will be ignored if we don't set the flag to `true` to take into account events that happened before the callback was assigned.

This PR also adds a QoS event test for events executor (the test will fail until the events support is completed in `rmw_cyclonedds_cpp` and `cyclonedds`)